### PR TITLE
base.html: Change non-ASCII characters to HTML entities

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -56,7 +56,7 @@
         <div class="row four-col">
           <div class="col">
             <h3 class="blog-title">
-              <a href="http://blogit.solita.fi/tyopoydalla">Työpöydällä</a>
+              <a href="http://blogit.solita.fi/tyopoydalla">Ty&ouml;p&ouml;yd&auml;ll&auml;</a>
             </h3>
             <p>
               <a href="http://blogit.solita.fi/tyopoydalla">http://blogit.solita.fi/tyopoydalla</a>
@@ -75,20 +75,20 @@
             </p>
           </div>
           <div class="col">
-            <h3 class="blog-title"><a href="http://blogit.solita.fi/alykasjohtaminen">Älykäs johtaminen</a></h3>
+            <h3 class="blog-title"><a href="http://blogit.solita.fi/alykasjohtaminen">&Auml;lyk&auml;s johtaminen</a></h3>
             <p>
               <a href="http://blogit.solita.fi/alykasjohtaminen">http://blogit.solita.fi/alykasjohtaminen</a>
             </p>
           </div>
         </div>
 
-        <p class="footer-slogan">Kaikki mikä voi, digitalisoituu.</p>
+        <p class="footer-slogan">Kaikki mik&auml; voi, digitalisoituu.</p>
 
         <p>
           <a href="http://www.solita.fi">
             <img class="logo" src="/img/solita-logo.png" alt="Solita" />
           </a>
-          Copyright © <a href="http://www.solita.fi">Solita Oy</a></a>
+          Copyright &copy; <a href="http://www.solita.fi">Solita Oy</a></a>
         </p>
 
       </div>


### PR DESCRIPTION
This fixes errors such as "incompatible character encodings: UTF-8 and CP850 in
base.html" on Windows.
