### PR TITLE
convert tags to lowercase where they are not names

### DIFF
--- a/_posts/2013-01-03-polyglot-programming.md
+++ b/_posts/2013-01-03-polyglot-programming.md
@@ -4,7 +4,7 @@ title: Polyglot programming
 author: harmia
 excerpt: The idea of polyglot programming is to render more natural and simpler solutions by combining the best solutions available from different programming languages and paradigms.
 tags: 
-- Polyglot programming
+- polyglot programming
 - poly-paradigm programming
 - multi-language programming
 - cross-language programming

--- a/_posts/2013-02-13-value-of-simplicity.md
+++ b/_posts/2013-02-13-value-of-simplicity.md
@@ -4,7 +4,7 @@ title: Value of Simplicity
 author: lokori
 excerpt: Seize the day and simplify your design. Finding a simple solution to a complex problem is one of the ultimate achievements. In this post I try to convince you and briefly touch the foundations on which one can build a simple solution. 
 tags: 
-- Simplicity
+- simplicity
 - software architecture 
 - software design 
 - normal form

--- a/_posts/2013-03-13-the-average-joe.md
+++ b/_posts/2013-03-13-the-average-joe.md
@@ -3,7 +3,7 @@ layout: post
 title: Our Faces Combined
 author: ruoat
 excerpt: I wanted to check what an average Solita employee looks like. I had images of all Solita employees' faces, OpenCV-library, Python and some free time.
-tags: opencv Python solita
+tags: OpenCV Python Solita
 ---
 When a new person joins Solita, they naturally get their photo taken. Recently, we had a company-wide staff photo update, where all the photos were taken in a standardized environment and the resulting photos all have identical lighting, colors, etc. This springed an idea: I could combine the photos and see what an average Solitan would look like.
 

--- a/_posts/2015-09-21-Hello-BadUSB.md
+++ b/_posts/2015-09-21-Hello-BadUSB.md
@@ -4,7 +4,7 @@ title: Hello BadUSB
 author: Rinorragi
 excerpt: Introduction to USB Rubber Ducky keystroke injection platform
 tags:  
-- Security
+- security
 - PowerShell
 ---
 

--- a/_posts/2015-12-11-ci-security-controls.md
+++ b/_posts/2015-12-11-ci-security-controls.md
@@ -8,7 +8,7 @@ categories:
 tags: 
 - EPiServer 
 - DOTNET 
-- Security
+- security
 ---
 Continuous integration and continuous delivery have been trendy topics lately. Among other things it is necessary to take care of security in your development process. I want to share few ideas how you can enhance your security in continuous integration in EPiServer CMS projects. [Need for speed](http://www.n4s.fi/en/) is a Finnish foundation and its purpose is to find new ways to deliver real time value for customers of Finnish software companies. There was a Q4 review this week at Rovaniemi and my blog post will be about [my presentation](http://www.slideshare.net/Solita_Oy/continuous-integration-and-security-testing-with-net?related=1) at there. 
 

--- a/_posts/2015-12-17-aloitepalvelut-cd.md
+++ b/_posts/2015-12-17-aloitepalvelut-cd.md
@@ -8,10 +8,10 @@ categories:
 - Automation
 tags:
 - Java
-- OpenSource
-- Continuous Delivery
-- Automation
-- Deployment Pipeline
+- open source
+- continuous delivery
+- automation
+- deployment pipeline
 - Ansible
 - Jenkins
 ---

--- a/_posts/2015-12-29-SQL-in-applications.md
+++ b/_posts/2015-12-29-SQL-in-applications.md
@@ -13,7 +13,7 @@ tags:
 - programming
 - Clojure
 - SQL
-- Security
+- security
 - simplicity
 - orthogonality
 - Python

--- a/_posts/2016-01-21-measuring-episerver-site-performance.md
+++ b/_posts/2016-01-21-measuring-episerver-site-performance.md
@@ -8,7 +8,7 @@ categories:
 tags: 
 - EPiServer
 - DOTNET
-- Performance
+- performance
 - JMeter
 ---
 Adequate performance is a critical requirement for any project, and one I want to nail before going live.

--- a/_posts/2016-02-01-testing-clojurescript-concurrency-with-servant.md
+++ b/_posts/2016-02-01-testing-clojurescript-concurrency-with-servant.md
@@ -4,8 +4,8 @@ title: Testing ClojureScript Concurrency with Servant
 author: jarzka
 excerpt: Web workers make it possible to create real multi-threaded web applications but they can be pain to work with. Does ClojureScript make it any easier?
 tags:
-- Web Workers
-- Multithreading
+- web workers
+- multithreading
 - Clojure
 - ClojureScript
 - Servant
@@ -24,7 +24,7 @@ But why do we need concurrency anyway? I believe most of the current JavaScript 
 
 ## Web workers save the day!
 
-Luckily things are getting better. HTML5 provides a facility to create real multi-threaded applications in JavaScript. This concept is called Web workers and it is already [well supported in all major web browsers](http://caniuse.com/#feat=webworkers). Creating web workers allows you to handle large tasks while ensuring that your app still remains responsive.
+Luckily things are getting better. HTML5 provides a facility to create real multi-threaded applications in JavaScript. This concept is called *web workers* and it is already [well supported in all major web browsers](http://caniuse.com/#feat=webworkers). Creating web workers allows you to handle large tasks while ensuring that your app still remains responsive.
 
 Problem solved? Not quite. There are some important limitations in web workers. Web worker scripts are almost completely separated from the main thread. In fact, they normally run in a separate JavaScript file (although it is possible to create [inline workers](http://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers)). This makes it difficult to share context; for example web workers cannot directly access the DOM or share data between each other. They also heavily rely on callback functions on sending and receiving messages between them and the main UI thread, which can sometimes be difficult to handle properly.
 


### PR DESCRIPTION
this is to ensure that words occur only once in tag cloud.  It has the nice side effect of documenting whether a word is a name (e.g. servant vs Servant).