### PR TITLE
Bump nokogiri version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -262,4 +262,4 @@ DEPENDENCIES
   therubyracer
 
 BUNDLED WITH
-   1.16.1
+   2.0.2


### PR DESCRIPTION
Fixes security alert in Github console (https://nvd.nist.gov/vuln/detail/CVE-2019-5477)