### PR TITLE
Remove Disqus for now

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,17 +44,4 @@ back_title: See all posts
     <script type="text/javascript">var addthis_config = {"data_track_addressbar":false};</script>
     <script type="text/javascript" src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4fc649c87892c488"></script>
     <!-- AddThis Button END -->
-
-    <div id="disqus_thread"></div>
-    <script type="text/javascript">
-        var disqus_shortname = 'solitadev';
-        var disqus_identifier = '{{ page.url }}';
-        var disqus_url = '{{ site.url }}{{ page.url }}';
-        (function() {
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-    </script>
-    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -157,4 +157,4 @@ If you currently have Ruby 1.x, you must first install Ruby 2 and then install t
 
 /dev/solita is built using all the hippiest hip technologies available:
 
-    git, Github Pages, Ruby, Jekyll, Markdown, Sass, Compass, foreman, jQuery, Gravatar, disqus, Google Analytics, AddThis
+    git, Github Pages, Ruby, Jekyll, Markdown, Sass, Compass, foreman, jQuery, Gravatar, Google Analytics, AddThis


### PR DESCRIPTION
Since we aren't currently paying for Disqus, it shows some pretty weird
ads below all blog posts. Remove at least for now.