### PR TITLE
Modify primary navigation to match the new one on solita.fi

### DIFF
--- a/_sass/partials/_primary-navigation.scss
+++ b/_sass/partials/_primary-navigation.scss
@@ -1,6 +1,5 @@
 .primary-navigation {
     display: none;
-    text-transform: uppercase;
     letter-spacing: .04rem;
     font-size: 0.875rem;
     line-height: (22/14);
@@ -14,10 +13,10 @@
     @media (min-width: $breakpoint-3) {
         font-size: 0.875rem;
         line-height: (22/14);
-        letter-spacing: .09rem;
     }
 
     &__items {
+        font-family: ShartSansDisplayNo1,Helvetica,Arial,sans-serif;
         list-style: none;
         padding: 0;
         margin: 0;


### PR DESCRIPTION
The navigation bars were changed on solita.fi, data.solita.fi and cloud.solita.fi.
This commit makes dev.solita.fi fit in too :)

Before:
![image](https://user-images.githubusercontent.com/16290563/141270271-ee699b2a-efe9-4a9e-99cf-0a11b1b40440.png)
After:
![image](https://user-images.githubusercontent.com/16290563/141270300-f022e8ba-db4a-4ef4-81e6-e0d1ff504dc2.png)