### PR TITLE
Added 'sudo' when changing groups directory

### DIFF
--- a/_posts/2021-12-21-docker-on-wsl2-without-docker-desktop.md
+++ b/_posts/2021-12-21-docker-on-wsl2-without-docker-desktop.md
@@ -68,7 +68,7 @@ Then it's time to create a launch script for `dockerd`. There are two options, m
        export DOCKER_HOST="unix://$DOCKER_SOCK"<br/>
     if [ ! -S "$DOCKER_SOCK" ]; then<br/>
     &nbsp;&nbsp;&nbsp;mkdir -pm o=,ug=rwx "$DOCKER_DIR"<br/>
-     &nbsp;&nbsp;&nbsp;chgrp docker "$DOCKER_DIR"<br/>
+     &nbsp;&nbsp;&nbsp;sudo chgrp docker "$DOCKER_DIR"<br/>
     &nbsp;&nbsp;&nbsp;/mnt/c/Windows/System32/wsl.exe -d $DOCKER_DISTRO sh -c "nohup sudo -b dockerd <code /dev/null > $DOCKER_DIR/dockerd.log 2>&1"<br/>
     fi
     </code>


### PR DESCRIPTION
Some setups may require 'sudo' when changing group directories. Since this doesn't cause any harm on setups that may not require it, it's better to have it documented.