### PR TITLE
Fixed code-block in 'dockerd'-section

### DIFF
--- a/_posts/2021-12-21-docker-on-wsl2-without-docker-desktop.md
+++ b/_posts/2021-12-21-docker-on-wsl2-without-docker-desktop.md
@@ -69,7 +69,7 @@ Then it's time to create a launch script for `dockerd`. There are two options, m
     if [ ! -S "$DOCKER_SOCK" ]; then<br/>
     &nbsp;&nbsp;&nbsp;mkdir -pm o=,ug=rwx "$DOCKER_DIR"<br/>
      &nbsp;&nbsp;&nbsp;sudo chgrp docker "$DOCKER_DIR"<br/>
-    &nbsp;&nbsp;&nbsp;/mnt/c/Windows/System32/wsl.exe -d $DOCKER_DISTRO sh -c "nohup sudo -b dockerd <code /dev/null > $DOCKER_DIR/dockerd.log 2>&1"<br/>
+    &nbsp;&nbsp;&nbsp;/mnt/c/Windows/System32/wsl.exe -d $DOCKER_DISTRO sh -c "nohup sudo -b dockerd &lt; /dev/null &gt; $DOCKER_DIR/dockerd.log 2&gt;&1"<br/>
     fi
     </code>
 - To manually run `dockerd`


### PR DESCRIPTION
The `code`-block in the 'dockerd'-section was causing VSCode to autofill tags in unwanted parts of the block. This has been fixed by using HTML-entities for less-than & greater-than inside the block.