### PR TITLE
Accessibility fixes

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,13 +1,13 @@
 <header class="site-header site-content-wrapper">
     <div class="site-header__branding">
-        <a href="https://www.solita.fi">
+        <a href="https://www.solita.fi" aria-label="Solita's website">
             <svg width="46" height="56" xmlns="http://www.w3.org/2000/svg">
                 <path d="M0 56V28h14v28H0zm32-28V0h14v28H32zM16 56V0h14v56H16z" fill="#282828" fill-rule="evenodd"></path>
             </svg>
         </a>
     </div>
 
-    <button id="menu-toggle" class="site-header__hamburger menu-toggle">
+    <button id="menu-toggle" class="site-header__hamburger menu-toggle" aria-label="Toggle menu">
         <svg class="menu-toggle__svg icon" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 100 100">
             <g class="menu-toggle__svg__g">
                 <path class="menu-toggle__svg__line menu-toggle__svg__line--1" d="M5 13h90v14H5z"></path>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,4 +1,4 @@
-<h5>/dev/solita</h5>
+<h2 class="sidebar-subtitle">/dev/solita</h2>
 <p>
     Writings from our fine developers.
 </p>
@@ -6,7 +6,7 @@
     <a href="https://www.solita.fi/en/careers/" rel="external">Work and write with us <span class="link-arrow-right"></span></a>
 </p>
 
-<h5>More about Solita</h5>
+<h2 class="sidebar-subtitle">More about Solita</h2>
 <div class="some-icons">
     <div>
         <a href="/rss.xml" rel="external" class="button-secondary-default-dark">
@@ -58,7 +58,7 @@
     </div>
 </div>
 
-<h5>Tags</h5>
+<h2 class="sidebar-subtitle">Tags</h2>
 <div class="tag-cloud">
     {% assign tags = site.tags | sort %}
     {% for tag in tags %}

--- a/_sass/partials/_menu-toggle.scss
+++ b/_sass/partials/_menu-toggle.scss
@@ -20,11 +20,6 @@
         }
     }
     
-    &:focus {
-        outline: thin dotted;
-        outline-offset: -2px;
-    }
-    
     &__svg {
         position: relative;
         height: 2rem;

--- a/_sass/partials/_sidebar.scss
+++ b/_sass/partials/_sidebar.scss
@@ -1,12 +1,23 @@
 .sidebar {
+  @mixin sidebar-heading {
+    border-top: 4px solid $brand-gray40;
+    padding-top: 1rem;
+    margin-top: 2rem;
+  }
+
+  .sidebar-subtitle {
+    @include sidebar-heading;
+    margin-bottom: 1rem;
+    font-weight: 700;
+    font-size: 1.125rem;
+  }
+
   *:first-child {
     margin-top: 0;
   }
 
   h5 {
-    border-top: 4px solid $brand-gray40;
-    padding-top: 1rem;
-    margin-top: 2rem;
+    @include sidebar-heading;
   }
 
   h4, h5 {

--- a/_sass/partials/_typography.scss
+++ b/_sass/partials/_typography.scss
@@ -229,6 +229,7 @@ h5 {
 a {
   color: $brand-red;
   text-decoration: none;
+  font-weight: 600;
 
   &:hover {
     @include link-hover;
@@ -309,8 +310,8 @@ caption {
 }
 
 blockquote {
-  border-left: 2px solid #bbb;
-  color: #888;
+  border-left: 2px solid $brand-red;
+  color: $brand-gray80;
   margin: 0 0 1.6em;
   padding-left: 2em;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -34,7 +34,7 @@
 
             avatar.render({}, directives);
             avatar.attr('href', url);
-            avatar.attr('aria-hidden', true)
+            avatar.attr('aria-hidden', true);
             $this.prepend(avatar);
         });
     });

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@
 
             avatar.render({}, directives);
             avatar.attr('href', url);
+            avatar.attr('aria-hidden', true)
             $this.prepend(avatar);
         });
     });


### PR DESCRIPTION
Fixed the following things:
- removed custom outline from hamburger menu button -> uses the same as all other buttons / links
- added aria-label texts to Solita logo link and hamburger menu
- sidebar headings are now h2 elements instead of h5 elements -> same styles are applied though
- link font weight is now 600 -> needed to get enough contrast according to APCA
- blockquote left border is now red -> stands out more
- blockquote text color is now brand-gray80 -> APCA says font-size should be at least 16.5 with font-weight of 400 for it to be completely accessible but I'm letting this one slide
- posts' authors' avatar has now an aria-hidden attribute so screen readers don't try to read them