### PR TITLE
Fix double curlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ If you want to write a post, here's how:
 7. Ask someone to review your post
 8. Publish by merging the branch
 
+### Formatting tips
+
+#### Double curlies
+
+To render double curly braces (`{{...text...}}`) in post content, you must surround it with raw-tags:
+
+```md
+{%- raw -%}
+printf("Hello, {{foo}}", foo)
+{% endraw %}
+```
+
+[More info in Jekyll docs](https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting).
+
 ## Understanding how the deploy works
 
 There are no workflows in this repo for the deploy - Github has builtin Jekyll based workflows

--- a/_posts/2024-01-12-azure-without-secrets-part-1.md
+++ b/_posts/2024-01-12-azure-without-secrets-part-1.md
@@ -95,6 +95,7 @@ Important parts here are:
 - Set the environment if you configured the federated credential subject to contain it.
 
 ```yaml
+{%- raw -%}
 ...
 
 jobs:
@@ -113,6 +114,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Show current account
         run: az account show
+{% endraw %}
 ```
 
 And that's it.


### PR DESCRIPTION
Jekyll eats double curlies ( `{{...text...}}` ) inside code blocks. [See starred note](https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting).

To render the code as is, we have to wrap it in `{%- raw -%}`/`{% endraw %}`. Additional dashes in the opening tag strips out the empty line it would otherwise leave behind.

Fixes the "See all posts Using Azure without secrets, Part 1" posts YAML code block, now showing the intended GitHub secret usage.

Also adds information in the repository README for future bloggers.

## Before ([Live at dev.solita.fi](https://dev.solita.fi/2024/01/12/azure-without-secrets-part-1.html))

See `jobs.steps.[].with.`

![image](https://github.com/user-attachments/assets/bcee9e05-fca3-4fb6-93d8-10f7b5a932fa)

## After (localhost)

![image](https://github.com/user-attachments/assets/caf55180-8265-4ceb-85c4-85fde168c2a8)
