### PR TITLE
Add /authors.html page

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -35,6 +35,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1 # uses version from .ruby-version file by default
+      - name: setup babashka
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          bb: latest
+      - name: generate authors data
+        run: bb authors.clj
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4

--- a/_data/authors.json
+++ b/_data/authors.json
@@ -1,4 +1,6 @@
-[
-    ["run: bb authors.clj" ["to", "generate", "real", "content"]]
-    ["authorname" ["_posts/some-post.md", "_posts/another-post.md"]]
-]
+[{"name":   "run: bb authors.clj",
+  "email":  "to generate this content",
+  "url":    "example.com",
+  "handle": "authors",
+  "posts":  [{"title":"We have always been at war with Eastasia",
+              "url":"/1984/04/21/war-with-eastasia.html"}]}]

--- a/_data/authors.json
+++ b/_data/authors.json
@@ -1,0 +1,4 @@
+[
+    ["run: bb authors.clj" ["to", "generate", "real", "content"]]
+    ["authorname" ["_posts/some-post.md", "_posts/another-post.md"]]
+]

--- a/authors.clj
+++ b/authors.clj
@@ -1,0 +1,25 @@
+#!/usr/bin/env bb
+(require '[clojure.string :as str]
+         '[clojure.data.json :as json])
+
+(def author->posts
+  (->> (java.io.File. "_posts")
+       .listFiles
+       (filter #(str/ends-with? (.getName %) ".md"))
+       (mapcat (fn [f]
+                 (for [author (-> (re-find #"(?im)^.*author: (.*)$" (slurp f))
+                                  second
+                                  (str/split #", "))]
+                   {:author author :post f})))
+       (group-by :author)
+       (into {} (map (fn [[author posts]]
+                       [author (map #(str "_posts/" (.getName (:post %))) posts)])))
+       (sort-by (comp count second))
+       reverse))
+
+#_(->> author-counts
+     (map (fn [[author count]] {:author author :count count}))
+     clojure.pprint/print-table)
+
+(spit "_data/authors.json" (json/write-str author->posts))
+;(println "total authors: " (count author-counts))

--- a/authors.clj
+++ b/authors.clj
@@ -1,29 +1,49 @@
 #!/usr/bin/env bb
 (require '[clojure.string :as str]
-         '[cheshire.core :as json])
+         '[cheshire.core :as json]
+         '[clj-yaml.core :as yaml])
+
+(defn file->relative-url
+  "Convert file like:
+  _posts/1984-04-21-war-with-eurasia.md
+
+to a jekyll page link:
+  /1984/04/21/war-with-eurasia.html"
+  [f]
+  (apply format "/%s/%s/%s/%s.html"
+         (drop 1 (re-find #"^(\d+)-(\d+)-(\d+)-(.*).md$" (.getName f)))))
+
+(def author-by-handle
+  (let [authors (-> "_config.yml" slurp yaml/parse-string :authors)]
+    (fn [author-name]
+      (authors (keyword author-name)))))
+
+(defn yaml-header [post-file]
+  (->> post-file slurp str/split-lines
+       (drop 1)
+       (take-while #(not= "---" %))
+       (str/join "\n")
+       yaml/parse-string))
 
 (def author->posts
   (->> (java.io.File. "_posts")
        .listFiles
        (filter #(str/ends-with? (.getName %) ".md"))
        (mapcat (fn [f]
-                 (let [contents (slurp f)
-                       [_ title] (re-find #"(?im)^title: (.*)$" contents)
-                       authors (-> (re-find #"(?im)^.*author: (.*)$" contents)
-                                   second
-                                   (str/split #", "))]
+                 (let [{:keys [title author]} (yaml-header f)
+                       authors (map str/trim (str/split author #","))]
                    (for [author authors]
-                     {:title title :author author :post (str "_posts/" (.getName f))}))))
+                     {:title title :author author :url (file->relative-url f)}))))
        (group-by :author)
-       (into {} (map (fn [[author posts]]
-                       ;; sort by date (part of filename)
-                       [author (reverse (sort-by :post posts))])))
-       (sort-by (comp count second))
+       (map (fn [[author posts]]
+              ;; sort by date (part of filename)
+              (assoc (author-by-handle author)
+                     :handle author
+                     :posts (->> posts
+                                 (map #(dissoc % :author))
+                                 (sort-by :url)
+                                 reverse))))
+       (sort-by (comp count :posts))
        reverse))
 
-#_(->> author-counts
-     (map (fn [[author count]] {:author author :count count}))
-     clojure.pprint/print-table)
-
 (spit "_data/authors.json" (json/generate-string author->posts))
-;(println "total authors: " (count author-counts))

--- a/authors.html
+++ b/authors.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Authors
+---
+
+{% assign authors = site.data.authors %}
+{% for author in authors %}
+  <h2 class='author-header' id="{{ author[0] | slugify }}-ref">{{ author[0] }}</h2>
+  <ul class="author-posts">
+    {% assign pages_list = tag[1] %}
+
+    {% for post in author[1] %}
+      <li><a href="{{post.post | absolute_url}}">{{post.title}}</a></li>
+    {% endfor %}
+  </ul>
+{% endfor %}

--- a/authors.html
+++ b/authors.html
@@ -5,12 +5,11 @@ title: Authors
 
 {% assign authors = site.data.authors %}
 {% for author in authors %}
-  <h2 class='author-header' id="{{ author[0] | slugify }}-ref">{{ author[0] }}</h2>
+<h2 class='author-header' id="{{author.handle}}">
+  <a href="{{author.url}}">{{ author.name }}</a></h2>
   <ul class="author-posts">
-    {% assign pages_list = tag[1] %}
-
-    {% for post in author[1] %}
-      <li><a href="{{post.post | absolute_url}}">{{post.title}}</a></li>
+    {% for post in author.posts %}
+      <li><a href="{{post.url}}">{{post.title}}</a></li>
     {% endfor %}
   </ul>
 {% endfor %}


### PR DESCRIPTION
Uses authors.clj babashka script to generate file `_data/authors.json` which contains all authors (in order of most posts).

authors.html is a regular jekyll template that renders author information similar to the tags page.

An author can be linked to by the handle (eg. `/authors.html#tatut`) 
