### PR TITLE
Add aria-hidden attribute to logo svg

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,7 +1,7 @@
 <header class="site-header site-content-wrapper">
     <div class="site-header__branding">
         <a href="https://www.solita.fi" aria-label="Solita's website">
-            <svg width="46" height="56" xmlns="http://www.w3.org/2000/svg">
+            <svg width="46" height="56" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path d="M0 56V28h14v28H0zm32-28V0h14v28H32zM16 56V0h14v56H16z" fill="#282828" fill-rule="evenodd"></path>
             </svg>
         </a>


### PR DESCRIPTION
I noticed the logo's svg did not have an aria-hidden attribute while I was writing my previous blog post. So here's a fix for that.