### PR TITLE
Nodejs migration

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -17,22 +17,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -63,6 +53,12 @@ jobs:
   # Deployment job
   deploy:
     if: github.ref == 'refs/heads/master'
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: ["master"]
 
+  pull_request:
+    branches: ["master"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -58,6 +61,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,18 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1 # uses version from .ruby-version file by default
+        uses: ruby/setup-ruby@v1.306.0 # uses version from .ruby-version file by default
       - name: setup babashka
-        uses: DeLaGuardo/setup-clojure@12.5
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           bb: latest
       - name: generate authors data
         run: bb authors.clj
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
@@ -54,7 +54,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
 
   # Deployment job
   deploy:
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v5.0.0
 

--- a/.github/workflows/rule-keeper.yml
+++ b/.github/workflows/rule-keeper.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.ref }}
       - name: Fetch history of master branch


### PR DESCRIPTION
- Update used GitHub Actions to their newest version to ensure they use non-deprecated versions of Node.js before GitHub removes Node.js 20
- Run site build on pull request to ensure the build works (both to test these updates and to ensure blog post pull requests build correctly) but only upload the build artifacts and publish the site from master
- Scope write permissions only to jobs that need them